### PR TITLE
refactor: update component versions and improve Ansible roles

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,9 +3,21 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,13 +41,17 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             Please review this pull request and provide feedback on:
-            - Ansible best practices and idempotency
-            - Security concerns (credentials, permissions)
-            - Kubernetes/ETCD configuration correctness
-            - Potential issues with templates (Jinja2)
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Ansible best practices and idempotency
+            - Security concerns (credentials, permissions)
+            - Kubernetes/ETCD configuration correctness
+            - Potential issues with templates (Jinja2)
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-      actions: read
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,5 +35,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Ansible-based automation for deploying highly available Kubernetes clusters with external ETCD, HAProxy load balancing, and Calico CNI.
 
-**Stack:** Ansible, Kubernetes 1.27.2, ETCD v3.5.7, Containerd, HAProxy 2.7.9, Calico 3.26.0
+**Stack:** Ansible, Kubernetes 1.31.4, ETCD v3.5.20, Containerd 1.7.24, HAProxy 3.0.7, Calico 3.29.1
 
 ## Common Commands
 
@@ -76,7 +76,7 @@ ansible-playbook -i hosts.ini copy-masters-certs.yml
 
 | Role | Purpose |
 |------|---------|
-| `etcd` | 3-node ETCD cluster with TLS (peer + client auth) using CFSSL |
+| `etcd` | Dynamic ETCD cluster with TLS (peer + client auth) using CFSSL |
 | `containerd` | Container runtime with systemd cgroup driver |
 | `kubelet` | Kubernetes node agent, kubeadm, kubectl |
 | `kube_masters` | Master initialization, join token, Calico CNI deployment |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ansible-based automation for deploying highly available Kubernetes clusters with external ETCD, HAProxy load balancing, and Calico CNI.
+
+**Stack:** Ansible, Kubernetes 1.27.2, ETCD v3.5.7, Containerd, HAProxy 2.7.9, Calico 3.26.0
+
+## Common Commands
+
+```bash
+# Full cluster installation
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml
+
+# Run specific components using tags
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t etcd
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t containerd
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kubelet
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kube_masters
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kube_workers
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t haproxy
+
+# Add new worker/ingress nodes to existing cluster
+ansible-playbook -i hosts.ini add_kubernetes_node.yml
+
+# Reset/teardown cluster
+ansible-playbook -i hosts.ini reset-cluster.yml
+
+# Deploy NTP for time synchronization
+ansible-playbook -i hosts.ini deploy-ntp.yml
+
+# Copy master certificates between nodes
+ansible-playbook -i hosts.ini copy-masters-certs.yml
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Ansible Control Machine                    │
+└──────────────────────────────────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+    ┌───────────┐       ┌───────────┐       ┌───────────┐
+    │  Master 0 │◄─────►│  Master 1 │◄─────►│  Master 2 │
+    │ ETCD+API  │       │ ETCD+API  │       │ ETCD+API  │
+    └───────────┘       └───────────┘       └───────────┘
+          │                   │                   │
+          └─────────┬─────────┴─────────┬─────────┘
+                    │ ETCD Cluster (TLS)│
+                    └─────────┬─────────┘
+                              │
+    ┌─────────────────────────┼─────────────────────────┐
+    │           HAProxy (on workers/ingress)            │
+    │      Load balances API requests to masters        │
+    └─────────────────────────┬─────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+    ┌───────────┐       ┌───────────┐       ┌───────────┐
+    │  Workers  │       │  Ingress  │       │    ...    │
+    │(HAProxy)  │       │ (HAProxy) │       │           │
+    └───────────┘       └───────────┘       └───────────┘
+```
+
+**Deployment Flow:**
+1. First master generates all certs (ETCD TLS + Kubernetes PKI)
+2. Certs fetched to control machine (`/tmp/k8s/`, `/tmp/etcd/certs/`)
+3. Certs distributed to other masters before initialization
+4. Workers join via token generated on first master
+
+## Ansible Roles
+
+| Role | Purpose |
+|------|---------|
+| `etcd` | 3-node ETCD cluster with TLS (peer + client auth) using CFSSL |
+| `containerd` | Container runtime with systemd cgroup driver |
+| `kubelet` | Kubernetes node agent, kubeadm, kubectl |
+| `kube_masters` | Master initialization, join token, Calico CNI deployment |
+| `kube_workers` | Worker node join using token from master |
+| `haproxy` | API load balancer (TCP 6443) with health checks |
+
+## Key Files
+
+- `group_vars/k8s.yml` - Version pinning, CIDR, tokens
+- `hosts.ini` / `stage-leaseweb.ini` - Inventory files defining node groups
+- `roles/*/templates/*.j2` - Jinja2 templates for configs (kubeadm, ETCD, HAProxy)
+
+## Inventory Groups
+
+- `kube_masters` - Control plane nodes (3 for HA)
+- `kube_workers` - Worker nodes
+- `kube_ingress` - Edge nodes running HAProxy
+- `k8s` - Parent group containing all cluster nodes
+
+## Certificate Locations
+
+**On Masters:**
+- `/etc/ssl/etcd/` - ETCD certificates
+- `/etc/kubernetes/pki/` - Kubernetes PKI
+
+**On Control Machine (temporary):**
+- `/tmp/k8s/` - Kubernetes certs and tokens
+- `/tmp/etcd/certs/` - ETCD certificates

--- a/README.md
+++ b/README.md
@@ -39,9 +39,17 @@ ansible-playbook -i hosts.ini install_kubernetes_cluster.yml
 | `deploy-ntp.yml` | Configure NTP |
 | `copy-masters-certs.yml` | Distribute master certificates |
 
+## Installation
+
+Full cluster (all components):
+
+```bash
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml
+```
+
 ## Tags
 
-Run specific components:
+Run specific components only:
 
 ```bash
 ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t etcd

--- a/README.md
+++ b/README.md
@@ -1,32 +1,63 @@
 # Deploying a High Available Kubernetes Cluster
 
+Ansible-based automation for deploying production-ready HA Kubernetes clusters.
 
-## The playbook deploys a highly available Kubernetes cluster by performing the following tasks:
+## Component Versions
 
-- Creating a temporary directory (/tmp/k8s) to store certificates
-- Installing kubelet, kubectl, and kubeadm on masters, workers, and ingress nodes
-- Setting up CRI on all nodes
-- Installing an ETCD cluster with TLS on master nodes
-- Initializing the first master node using kubeadm and creating cluster certificates
-- Adding remaining master nodes to the cluster
-- Installing CNI for network configuration
-- Adding worker nodes to the cluster
-- Setting up HAProxy as API load balancer
-- Configuring the ingress controller
-- Setting up Helm for package management."
+| Component | Version |
+|-----------|---------|
+| Kubernetes | 1.31.4 |
+| ETCD | v3.5.20 |
+| Containerd | 1.7.24 |
+| Calico CNI | 3.29.1 |
+| HAProxy | 3.0.7 |
 
+## Features
 
-## Getting started:
+- Dynamic master count (3, 5, 7+ nodes)
+- External ETCD cluster with TLS (ECDSA certificates)
+- HAProxy load balancer for API server
+- Calico CNI networking
+- Secure token handling (24h TTL)
+
+## Quick Start
 
 ```bash
 git clone https://github.com/rjeka/k8s-easy-ha-cluster.git
 cd k8s-easy-ha-cluster
 vim hosts.ini
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml
 ```
 
+## Available Playbooks
+
+| Playbook | Description |
+|----------|-------------|
+| `install_kubernetes_cluster.yml` | Full cluster installation |
+| `add_kubernetes_node.yml` | Add new worker/ingress nodes |
+| `reset-cluster.yml` | Teardown cluster |
+| `deploy-ntp.yml` | Configure NTP |
+| `copy-masters-certs.yml` | Distribute master certificates |
+
+## Tags
+
+Run specific components:
+
 ```bash
-ansible-playbook -i <inventory> install_kubernetes_cluster.yml
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t etcd
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t containerd
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kubelet
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kube_masters
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t kube_workers
+ansible-playbook -i hosts.ini install_kubernetes_cluster.yml -t haproxy
 ```
+
+## Inventory Groups
+
+- `kube_masters` - Control plane nodes
+- `kube_workers` - Worker nodes
+- `kube_ingress` - Ingress nodes with HAProxy
+- `k8s` - All cluster nodes
 
 
 

--- a/group_vars/k8s.yml
+++ b/group_vars/k8s.yml
@@ -1,8 +1,14 @@
+# ETCD Configuration
 etcd_token: sthxidhv9vyxQ34cBrDQeYcS6x
-etcd_version: v3.5.7
+etcd_version: v3.5.20
 
-crictl_version: "v1.26.0"
-
-kubeVersion: 1.27.2
+# Kubernetes Configuration
+kubeVersion: "1.31.4"
 CIDR: 192.168.22.0/20
-calico_version: 3.26.0
+
+# Component Versions
+calico_version: "3.29.1"
+crictl_version: "v1.31.1"
+containerd_version: "1.7.24"
+haproxy_version: "3.0.7"
+cfssl_version: "1.6.5"

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Containerd version to install
+containerd_version: "1.7.24"
+
+# Containerd configuration directory
+containerd_config_dir: "/etc/containerd"
+
+# Pause image for sandbox containers
+# Should match Kubernetes version requirements
+pause_image: "registry.k8s.io/pause:3.10"
+
+# crictl version
+crictl_version: "v1.31.1"
+
+# Docker repository GPG key
+docker_gpg_key_url: "https://download.docker.com/linux/ubuntu/gpg"
+docker_gpg_keyring_path: "/etc/apt/keyrings/docker.gpg"
+
+# Architecture mapping for apt repository
+containerd_arch_map:
+  x86_64: "amd64"
+  aarch64: "arm64"

--- a/roles/containerd/handlers/main.yaml
+++ b/roles/containerd/handlers/main.yaml
@@ -1,4 +1,0 @@
----
-
-- name: restart containerd
-  service: name=containerd state=restarted

--- a/roles/containerd/handlers/main.yml
+++ b/roles/containerd/handlers/main.yml
@@ -1,0 +1,21 @@
+---
+- name: restart containerd
+  ansible.builtin.service:
+    name: containerd
+    state: restarted
+  register: containerd_restart_result
+
+- name: Verify containerd is running after restart
+  ansible.builtin.service_facts:
+  register: services_state
+  until: services_state.ansible_facts.services['containerd.service'].state == 'running'
+  retries: 5
+  delay: 2
+  listen: restart containerd
+
+- name: Verify containerd socket is available
+  ansible.builtin.wait_for:
+    path: /var/run/containerd/containerd.sock
+    state: present
+    timeout: 30
+  listen: restart containerd

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Validate supported architecture
+  ansible.builtin.fail:
+    msg: "Unsupported architecture: {{ ansible_architecture }}. Supported: x86_64, aarch64"
+  when: ansible_architecture not in containerd_arch_map
+  tags: containerd
+
 - name: Deploy crictl {{ crictl_version }}
   ansible.builtin.unarchive:
     src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-linux-{{ containerd_arch_map[ansible_architecture] | default('amd64') }}.tar.gz"
@@ -81,7 +87,7 @@
 
 - name: Install containerd {{ containerd_version }}
   ansible.builtin.apt:
-    name: "containerd.io={{ containerd_version }}*"
+    name: "containerd.io={{ containerd_version }}-1"
     update_cache: yes
     allow_downgrade: yes
   tags: containerd

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -1,73 +1,132 @@
 ---
-- name: deploy crictl {{ crictl_version }}
-
-
-  unarchive:
-    src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-linux-amd64.tar.gz"
+- name: Deploy crictl {{ crictl_version }}
+  ansible.builtin.unarchive:
+    src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-linux-{{ containerd_arch_map[ansible_architecture] | default('amd64') }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: yes
-  tags: containerd  
-
-- name: create containerd.conf
-  template:
-    src: containerd.conf.j2
-    dest: /etc/modules-load.d/containerd.conf
   tags: containerd
 
-- name: create kernel module
+- name: Create containerd kernel modules config
+  ansible.builtin.template:
+    src: containerd.conf.j2
+    dest: /etc/modules-load.d/containerd.conf
+    mode: '0644'
+  tags: containerd
+
+- name: Load required kernel modules
   community.general.modprobe:
     name: "{{ item }}"
+    persistent: present
   loop:
     - overlay
     - br_netfilter
   tags: containerd
 
-- name: set sysctl values
+- name: Configure sysctl parameters for Kubernetes
   ansible.posix.sysctl:
     name: "{{ item }}"
     value: "1"
+    sysctl_file: /etc/sysctl.d/99-kubernetes-cri.conf
+    reload: yes
   loop:
     - net.bridge.bridge-nf-call-iptables
     - net.ipv4.ip_forward
     - net.bridge.bridge-nf-call-ip6tables
   tags: containerd
 
-- name: Preinstall packages
-  apt:
-    name: ['apt-transport-https', 'ca-certificates', 'software-properties-common', 'curl']
-    update_cache: yes
-  tags: containerd
-
-- name: Add docker gpg key
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: present
-  tags: containerd
-
-- name:  Get docker repositorie
-  ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
-    state: present
-  tags: containerd  
-
-- name: install containerd
+- name: Install prerequisite packages
   ansible.builtin.apt:
-    name: containerd.io 
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - software-properties-common
+      - curl
+      - gnupg
     update_cache: yes
   tags: containerd
 
-- name: create config
-  file:
-    path: /etc/containerd
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
     state: directory
+    mode: '0755'
   tags: containerd
 
+- name: Download Docker GPG key
+  ansible.builtin.get_url:
+    url: "{{ docker_gpg_key_url }}"
+    dest: /tmp/docker.gpg.armored
+    mode: '0644'
+  tags: containerd
 
-- name: create default config
-  shell: |
-    containerd config default | sudo tee /etc/containerd/config.toml && crictl config runtime-endpoint unix:///var/run/containerd/containerd.sock && \
-    sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml && \
-    PAUSE_IMAGE=$(kubeadm config images list | grep pause) && \
-    sed -i "s,sandbox_image = .*,sandbox_image = \"$PAUSE_IMAGE\",g" /etc/containerd/config.toml
+- name: Dearmor Docker GPG key
+  ansible.builtin.shell: |
+    gpg --dearmor < /tmp/docker.gpg.armored > {{ docker_gpg_keyring_path }}
+  args:
+    creates: "{{ docker_gpg_keyring_path }}"
+  tags: containerd
+
+- name: Set permissions on Docker GPG keyring
+  ansible.builtin.file:
+    path: "{{ docker_gpg_keyring_path }}"
+    mode: '0644'
+  tags: containerd
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ containerd_arch_map[ansible_architecture] | default('amd64') }} signed-by={{ docker_gpg_keyring_path }}] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: present
+    filename: docker
+  tags: containerd
+
+- name: Install containerd {{ containerd_version }}
+  ansible.builtin.apt:
+    name: "containerd.io={{ containerd_version }}*"
+    update_cache: yes
+    allow_downgrade: yes
+  tags: containerd
+
+- name: Hold containerd package version
+  ansible.builtin.dpkg_selections:
+    name: containerd.io
+    selection: hold
+  tags: containerd
+
+- name: Create containerd config directory
+  ansible.builtin.file:
+    path: "{{ containerd_config_dir }}"
+    state: directory
+    mode: '0755'
+  tags: containerd
+
+- name: Deploy containerd configuration
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: "{{ containerd_config_dir }}/config.toml"
+    mode: '0644'
+    backup: yes
   notify: restart containerd
+  tags: containerd
+
+- name: Configure crictl runtime endpoint
+  ansible.builtin.copy:
+    dest: /etc/crictl.yaml
+    content: |
+      runtime-endpoint: unix:///var/run/containerd/containerd.sock
+      image-endpoint: unix:///var/run/containerd/containerd.sock
+      timeout: 10
+    mode: '0644'
+  tags: containerd
+
+- name: Ensure containerd is started and enabled
+  ansible.builtin.service:
+    name: containerd
+    state: started
+    enabled: yes
+  tags: containerd
+
+- name: Clean up temporary GPG key file
+  ansible.builtin.file:
+    path: /tmp/docker.gpg.armored
+    state: absent
   tags: containerd

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -1,0 +1,21 @@
+# Containerd configuration file
+# Managed by Ansible - do not edit manually
+
+version = 2
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "{{ pause_image }}"
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# ETCD version
+etcd_version: "v3.5.20"
+
+# ETCD data directory
+etcd_data_dir: "/var/lib/etcd"
+
+# ETCD SSL directory
+etcd_ssl_dir: "/etc/ssl/etcd"
+
+# ETCD working directory for certificate generation
+etcd_cert_work_dir: "/opt/etcd-ssl"
+
+# CFSSL version for certificate generation
+cfssl_version: "1.6.5"
+
+# ETCD cluster token (override in group_vars)
+etcd_token: "etcd-cluster-token"
+
+# Certificate algorithm (ecdsa is more secure and faster than rsa)
+etcd_cert_algo: "ecdsa"
+etcd_cert_size: 256

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart etcd
+  systemd:
+    name: etcd
+    state: restarted
+    daemon_reload: yes
+  become: yes
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+  become: yes

--- a/roles/etcd/tasks/etcd.yml
+++ b/roles/etcd/tasks/etcd.yml
@@ -51,3 +51,25 @@
     enabled: yes
     daemon_reload: yes
   tags: etcd
+
+- name: Wait for etcd to be ready
+  wait_for:
+    port: 2379
+    host: "{{ ansible_host }}"
+    delay: 5
+    timeout: 60
+  tags: etcd
+
+- name: Verify etcd cluster health
+  shell: |
+    etcdctl endpoint health \
+      --endpoints=https://{{ ansible_host }}:2379 \
+      --cacert={{ etcd_ssl_dir }}/ca.pem \
+      --cert={{ etcd_ssl_dir }}/client.pem \
+      --key={{ etcd_ssl_dir }}/client-key.pem
+  register: etcd_health
+  retries: 5
+  delay: 10
+  until: etcd_health.rc == 0
+  changed_when: false
+  tags: etcd

--- a/roles/etcd/tasks/etcd.yml
+++ b/roles/etcd/tasks/etcd.yml
@@ -1,36 +1,50 @@
-- name: Create dirs
+---
+- name: Create archive directory
   file:
     path: /opt/archives
     state: directory
   tags: etcd
 
-
-- name: Get etcd archive
+- name: Download etcd archive
   get_url:
-    url: https://github.com/coreos/etcd/releases/download/{{etcd_version}}/etcd-{{etcd_version}}-linux-amd64.tar.gz
-    dest: /opt/archives/etcd-{{etcd_version}}-linux-amd64.tar.gz
+    url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    dest: "/opt/archives/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
   tags: etcd
 
-- name: Get and unpack etcd
-  shell: |
-    tar -xvf etcd-{{etcd_version}}-linux-amd64.tar.gz -C /usr/local/bin/ --strip-components=1
-  args:
-    chdir: /opt/archives
+- name: Extract etcd binaries
+  unarchive:
+    src: "/opt/archives/etcd-{{ etcd_version }}-linux-amd64.tar.gz"
+    dest: /usr/local/bin/
+    remote_src: yes
+    extra_opts:
+      - --strip-components=1
+    creates: /usr/local/bin/etcd
+  tags: etcd
+
+- name: Create etcd data directory
+  file:
+    path: "{{ etcd_data_dir }}"
+    state: directory
+    mode: '0700'
   tags: etcd
 
 - name: Create systemd service for etcd
   template:
     src: etcd.service.j2
-    dest: "/etc/systemd/system/etcd.service"
+    dest: /etc/systemd/system/etcd.service
+    mode: '0644'
+  notify: restart etcd
   tags: etcd
 
-- name: Create etcd env file
+- name: Create etcd environment file
   template:
     src: etcd.env.j2
     dest: /etc/etcd.env
+    mode: '0644'
+  notify: restart etcd
   tags: etcd
 
-- name: Enable and start etc cluster
+- name: Enable and start etcd cluster
   systemd:
     name: etcd
     state: started

--- a/roles/etcd/tasks/tls.yml
+++ b/roles/etcd/tasks/tls.yml
@@ -1,113 +1,123 @@
 ---
-#https://mcs.mail.ru/blog/zapuskaem-etcd-klaster-dlya-kubernetes
-#https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+# ETCD TLS Certificate Generation
+# References:
+# - https://mcs.mail.ru/blog/zapuskaem-etcd-klaster-dlya-kubernetes
+# - https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
 
-- name: recreate etcd ssl dir
+- name: Recreate etcd ssl working directory
   file:
-    path: /opt/etcd-ssl
+    path: "{{ etcd_cert_work_dir }}"
     state: "{{ item }}"
   loop:
     - absent
     - directory
   tags: ssl
 
-
-- name: install cfssl
+- name: Install cfssl tools
   get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
-    mode: a+x
+    mode: '0755'
   loop:
-    - { url: 'https://pkg.cfssl.org/R1.2/cfssl_linux-amd64', dest: '/usr/local/bin/cfssl' }
-    - { url: 'https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64', dest: '/usr/local/bin/cfssljson' }
+    - url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssl_{{ cfssl_version }}_linux_amd64"
+      dest: /usr/local/bin/cfssl
+    - url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssljson_{{ cfssl_version }}_linux_amd64"
+      dest: /usr/local/bin/cfssljson
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-
-- name: create ca-config.json
+- name: Create ca-config.json
   template:
     src: ca-config.json.j2
-    dest: /opt/etcd-ssl/ca-config.json
+    dest: "{{ etcd_cert_work_dir }}/ca-config.json"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-- name: create ca-csr.json
+- name: Create ca-csr.json
   template:
     src: ca-csr.json.j2
-    dest: /opt/etcd-ssl/ca-csr.json
+    dest: "{{ etcd_cert_work_dir }}/ca-csr.json"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-
-- name: generating a new CA
+- name: Generate new CA certificate
   shell: |
     cfssl gencert -initca ca-csr.json | cfssljson -bare ca -
   args:
-    chdir: /opt/etcd-ssl
+    chdir: "{{ etcd_cert_work_dir }}"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-- name: create server cert
+- name: Create server certificates for all masters
   shell: |
-    echo "{\"CN\":\"{{ item.hostname }}\",\"hosts\":[\"\"],\"key\":{\"algo\":\"rsa\",\"size\":2048}}" | cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=server -hostname="{{ item.ip }},{{ item.hostname }}" - | cfssljson -bare {{ item.hostname }}
+    echo '{"CN":"{{ hostvars[item]['ansible_hostname'] }}","hosts":[""],"key":{"algo":"{{ etcd_cert_algo }}","size":{{ etcd_cert_size }}}}' | \
+    cfssl gencert \
+      -ca=ca.pem \
+      -ca-key=ca-key.pem \
+      -config=ca-config.json \
+      -profile=server \
+      -hostname="{{ hostvars[item]['ansible_host'] }},{{ hostvars[item]['ansible_hostname'] }}" - | \
+    cfssljson -bare {{ hostvars[item]['ansible_hostname'] }}
   args:
-    chdir: /opt/etcd-ssl
-  loop:
-    - { hostname: "{{hostvars[groups['kube_masters'][0]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][0]]['ansible_host']}}" }
-    - { hostname: "{{hostvars[groups['kube_masters'][1]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][1]]['ansible_host']}}" }
-    - { hostname: "{{hostvars[groups['kube_masters'][2]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][2]]['ansible_host']}}" }
+    chdir: "{{ etcd_cert_work_dir }}"
+  loop: "{{ groups['kube_masters'] }}"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-- name: create peer cert
+- name: Create peer certificates for all masters
   shell: |
-    echo "{\"CN\":\"{{ item.hostname }}\",\"hosts\":[\"\"],\"key\":{\"algo\":\"rsa\",\"size\":2048}}" | cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=peer -hostname="{{ item.ip }},{{ item.hostname }}" - | cfssljson -bare {{ item.hostname }}-peer
+    echo '{"CN":"{{ hostvars[item]['ansible_hostname'] }}","hosts":[""],"key":{"algo":"{{ etcd_cert_algo }}","size":{{ etcd_cert_size }}}}' | \
+    cfssl gencert \
+      -ca=ca.pem \
+      -ca-key=ca-key.pem \
+      -config=ca-config.json \
+      -profile=peer \
+      -hostname="{{ hostvars[item]['ansible_host'] }},{{ hostvars[item]['ansible_hostname'] }}" - | \
+    cfssljson -bare {{ hostvars[item]['ansible_hostname'] }}-peer
   args:
-    chdir: /opt/etcd-ssl
-  loop:
-    - { hostname: "{{hostvars[groups['kube_masters'][0]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][0]]['ansible_host']}}" }
-    - { hostname: "{{hostvars[groups['kube_masters'][1]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][1]]['ansible_host']}}" }
-    - { hostname: "{{hostvars[groups['kube_masters'][2]]['ansible_hostname']}}", ip: "{{hostvars[groups['kube_masters'][2]]['ansible_host']}}" }
+    chdir: "{{ etcd_cert_work_dir }}"
+  loop: "{{ groups['kube_masters'] }}"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-- name: create client certificate
+- name: Create client certificate
   shell: |
-    echo '{"CN":"client","key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client - | cfssljson -bare client
+    echo '{"CN":"client","key":{"algo":"{{ etcd_cert_algo }}","size":{{ etcd_cert_size }}}}' | \
+    cfssl gencert \
+      -ca=ca.pem \
+      -ca-key=ca-key.pem \
+      -config=ca-config.json \
+      -profile=client - | \
+    cfssljson -bare client
   args:
-    chdir: /opt/etcd-ssl
+    chdir: "{{ etcd_cert_work_dir }}"
   tags: ssl
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  when: inventory_hostname == groups['kube_masters'][0]
 
-
-- name: Get file names to copy
-  shell: |
-    ls -1
-  register: files_to_copy
-  args:
-    chdir: /opt/etcd-ssl
+- name: Get list of generated certificate files
+  find:
+    paths: "{{ etcd_cert_work_dir }}"
+    patterns: "*"
+  register: cert_files
+  when: inventory_hostname == groups['kube_masters'][0]
   tags:
     - ssl
     - copy
 
-
-
-- name: Copy cert to ansiblehost
+- name: Fetch certificates to ansible controller
   fetch:
-    src: "/opt/etcd-ssl/{{ item }}"
-    dest: "/tmp/etcd/certs/{{ item }}"
+    src: "{{ item.path }}"
+    dest: "/tmp/etcd/certs/{{ item.path | basename }}"
     flat: yes
-  with_items:
-    - "{{ files_to_copy.stdout_lines }}"
-  when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
+  loop: "{{ cert_files.files }}"
+  when: inventory_hostname == groups['kube_masters'][0]
   tags:
     - ssl
     - copy
 
-
-- name: create ssl dir
+- name: Recreate etcd ssl directory on all masters
   file:
-    path: /etc/ssl/etcd
+    path: "{{ etcd_ssl_dir }}"
     state: "{{ item }}"
   loop:
     - absent
@@ -115,22 +125,19 @@
   tags:
     - ssl
 
-
-- name: copy cert to etcd nodes
+- name: Copy certificates to etcd nodes
   copy:
     src: "/tmp/etcd/certs/{{ item }}"
-    dest: "/etc/ssl/etcd/{{ item }}"
+    dest: "{{ etcd_ssl_dir }}/{{ item }}"
+    mode: '0600'
   loop:
     - "ca.pem"
-    - "{{ansible_hostname}}.pem"
-    - "{{ansible_hostname}}-key.pem"
-    - "{{ansible_hostname}}-peer.pem"
-    - "{{ansible_hostname}}-peer-key.pem"
+    - "{{ ansible_hostname }}.pem"
+    - "{{ ansible_hostname }}-key.pem"
+    - "{{ ansible_hostname }}-peer.pem"
+    - "{{ ansible_hostname }}-peer-key.pem"
     - "client.pem"
     - "client-key.pem"
   tags:
     - ssl
     - copy
-
-
-

--- a/roles/etcd/tasks/tls.yml
+++ b/roles/etcd/tasks/tls.yml
@@ -4,6 +4,14 @@
 # - https://mcs.mail.ru/blog/zapuskaem-etcd-klaster-dlya-kubernetes
 # - https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
 
+- name: Clean up old certs on ansible controller
+  file:
+    path: /tmp/etcd/certs
+    state: absent
+  delegate_to: localhost
+  run_once: true
+  tags: ssl
+
 - name: Recreate etcd ssl working directory
   file:
     path: "{{ etcd_cert_work_dir }}"

--- a/roles/etcd/tasks/tls.yml
+++ b/roles/etcd/tasks/tls.yml
@@ -4,21 +4,26 @@
 # - https://mcs.mail.ru/blog/zapuskaem-etcd-klaster-dlya-kubernetes
 # - https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
 
+- name: Check if CA certificate already exists
+  stat:
+    path: "{{ etcd_ssl_dir }}/ca.pem"
+  register: etcd_ca_exists
+  tags: ssl
+
 - name: Clean up old certs on ansible controller
   file:
     path: /tmp/etcd/certs
     state: absent
   delegate_to: localhost
   run_once: true
+  when: not etcd_ca_exists.stat.exists
   tags: ssl
 
-- name: Recreate etcd ssl working directory
+- name: Create etcd ssl working directory
   file:
     path: "{{ etcd_cert_work_dir }}"
-    state: "{{ item }}"
-  loop:
-    - absent
-    - directory
+    state: directory
+  when: not etcd_ca_exists.stat.exists
   tags: ssl
 
 - name: Install cfssl tools
@@ -32,21 +37,27 @@
     - url: "https://github.com/cloudflare/cfssl/releases/download/v{{ cfssl_version }}/cfssljson_{{ cfssl_version }}_linux_amd64"
       dest: /usr/local/bin/cfssljson
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Create ca-config.json
   template:
     src: ca-config.json.j2
     dest: "{{ etcd_cert_work_dir }}/ca-config.json"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Create ca-csr.json
   template:
     src: ca-csr.json.j2
     dest: "{{ etcd_cert_work_dir }}/ca-csr.json"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Generate new CA certificate
   shell: |
@@ -54,7 +65,9 @@
   args:
     chdir: "{{ etcd_cert_work_dir }}"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Create server certificates for all masters
   shell: |
@@ -70,7 +83,9 @@
     chdir: "{{ etcd_cert_work_dir }}"
   loop: "{{ groups['kube_masters'] }}"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Create peer certificates for all masters
   shell: |
@@ -86,7 +101,9 @@
     chdir: "{{ etcd_cert_work_dir }}"
   loop: "{{ groups['kube_masters'] }}"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Create client certificate
   shell: |
@@ -100,14 +117,18 @@
   args:
     chdir: "{{ etcd_cert_work_dir }}"
   tags: ssl
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
 
 - name: Get list of generated certificate files
   find:
     paths: "{{ etcd_cert_work_dir }}"
     patterns: "*"
   register: cert_files
-  when: inventory_hostname == groups['kube_masters'][0]
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
   tags:
     - ssl
     - copy
@@ -117,19 +138,20 @@
     src: "{{ item.path }}"
     dest: "/tmp/etcd/certs/{{ item.path | basename }}"
     flat: yes
-  loop: "{{ cert_files.files }}"
-  when: inventory_hostname == groups['kube_masters'][0]
+  loop: "{{ cert_files.files | default([]) }}"
+  when:
+    - inventory_hostname == groups['kube_masters'][0]
+    - not etcd_ca_exists.stat.exists
   tags:
     - ssl
     - copy
 
-- name: Recreate etcd ssl directory on all masters
+- name: Create etcd ssl directory on all masters
   file:
     path: "{{ etcd_ssl_dir }}"
-    state: "{{ item }}"
-  loop:
-    - absent
-    - directory
+    state: directory
+    mode: '0700'
+  when: not etcd_ca_exists.stat.exists
   tags:
     - ssl
 
@@ -146,6 +168,7 @@
     - "{{ ansible_hostname }}-peer-key.pem"
     - "client.pem"
     - "client-key.pem"
+  when: not etcd_ca_exists.stat.exists
   tags:
     - ssl
     - copy

--- a/roles/etcd/templates/ca-csr.json.j2
+++ b/roles/etcd/templates/ca-csr.json.j2
@@ -1,16 +1,16 @@
 {
-  "CN": "crpt",
+  "CN": "etcd-ca",
   "key": {
-    "algo": "rsa",
-    "size": 2048
+    "algo": "{{ etcd_cert_algo }}",
+    "size": {{ etcd_cert_size }}
   },
   "names": [
-  {
-    "C": "RU",
-    "ST": "RU",
-    "L": "SPB",
-    "O": "k8s",
-    "OU": "System"
-  }
+    {
+      "C": "RU",
+      "ST": "RU",
+      "L": "SPB",
+      "O": "k8s",
+      "OU": "System"
+    }
   ]
 }

--- a/roles/etcd/templates/etcd.service.j2
+++ b/roles/etcd/templates/etcd.service.j2
@@ -14,23 +14,22 @@ TimeoutStartSec=0
 
 ExecStart=/usr/local/bin/etcd \
   --name {{ ansible_hostname }} \
-  --data-dir /var/lib/etcd \
+  --data-dir {{ etcd_data_dir }} \
   --listen-client-urls https://{{ ansible_host }}:2379 \
   --advertise-client-urls https://{{ ansible_host }}:2379 \
-  --listen-peer-urls https://{{ ansible_host }}:2380 --initial-advertise-peer-urls https://{{ ansible_host }}:2380 \
-  --initial-cluster {{ hostvars[groups['kube_masters'][0]]['ansible_hostname'] }}=https://{{ hostvars[groups['kube_masters'][0]]['ansible_host'] }}:2380,{{ hostvars[groups['kube_masters'][1]]['ansible_hostname'] }}=https://{{ hostvars[groups['kube_masters'][1]]['ansible_host'] }}:2380,{{ hostvars[groups['kube_masters'][2]]['ansible_hostname'] }}=https://{{ hostvars[groups['kube_masters'][2]]['ansible_host'] }}:2380 \
+  --listen-peer-urls https://{{ ansible_host }}:2380 \
+  --initial-advertise-peer-urls https://{{ ansible_host }}:2380 \
+  --initial-cluster {% for host in groups['kube_masters'] %}{{ hostvars[host]['ansible_hostname'] }}=https://{{ hostvars[host]['ansible_host'] }}:2380{% if not loop.last %},{% endif %}{% endfor %} \
   --initial-cluster-token {{ etcd_token }} \
   --initial-cluster-state new \
   --client-cert-auth \
-  --trusted-ca-file /etc/ssl/etcd/ca.pem \
-  --cert-file /etc/ssl/etcd/{{ ansible_hostname }}.pem \
-  --key-file /etc/ssl/etcd/{{ ansible_hostname }}-key.pem \
+  --trusted-ca-file {{ etcd_ssl_dir }}/ca.pem \
+  --cert-file {{ etcd_ssl_dir }}/{{ ansible_hostname }}.pem \
+  --key-file {{ etcd_ssl_dir }}/{{ ansible_hostname }}-key.pem \
   --peer-client-cert-auth \
-  --peer-trusted-ca-file /etc/ssl/etcd/ca.pem \
-  --peer-cert-file /etc/ssl/etcd/{{ ansible_hostname }}-peer.pem \
-  --peer-key-file /etc/ssl/etcd/{{ ansible_hostname }}-peer-key.pem
-
-
+  --peer-trusted-ca-file {{ etcd_ssl_dir }}/ca.pem \
+  --peer-cert-file {{ etcd_ssl_dir }}/{{ ansible_hostname }}-peer.pem \
+  --peer-key-file {{ etcd_ssl_dir }}/{{ ansible_hostname }}-peer-key.pem
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+haproxy_version: "3.0"
+haproxy_stats_port: 8404
+haproxy_stats_uri: /stats
+haproxy_stats_refresh: 10s

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -3,3 +3,5 @@ haproxy_version: "3.0"
 haproxy_stats_port: 8404
 haproxy_stats_uri: /stats
 haproxy_stats_refresh: 10s
+haproxy_stats_user: admin
+haproxy_stats_password: changeme

--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -1,0 +1,16 @@
+---
+- name: restart haproxy
+  ansible.builtin.systemd:
+    name: haproxy
+    state: restarted
+    daemon_reload: yes
+
+- name: reload haproxy
+  ansible.builtin.systemd:
+    name: haproxy
+    state: reloaded
+
+- name: restart kubelet
+  ansible.builtin.systemd:
+    name: kubelet
+    state: restarted

--- a/roles/haproxy/tasks/configs.yml
+++ b/roles/haproxy/tasks/configs.yml
@@ -1,24 +1,30 @@
 ---
-- name: create haproxy config
-  template:
+- name: Create HAProxy configuration
+  ansible.builtin.template:
     src: haproxy.cfg.j2
     dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: '0644'
+    validate: haproxy -c -f %s
+  notify: reload haproxy
   tags: haproxy
 
-- name: restart haproxy
-  service: 
-    name: haproxy
-    state: restarted  
-  tags: haproxy  
+- name: Check if kubelet.conf exists
+  ansible.builtin.stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: kubelet_conf_stat
+  tags: haproxy
 
+- name: Update kubelet.conf server address to localhost
+  ansible.builtin.replace:
+    path: /etc/kubernetes/kubelet.conf
+    regexp: 'server: https://{{ hostvars[groups["kube_masters"][0]]["ansible_host"] }}:6443'
+    replace: 'server: https://127.0.0.1:6443'
+  notify: restart kubelet
+  tags: haproxy
+  when: kubelet_conf_stat.stat.exists
 
-- name: changed kubelet configs
-  shell: |
-    sed -i 's/{{ hostvars[groups['kube_masters'][0]]['ansible_host'] }}/127.0.0.1/g'  /etc/kubernetes/kubelet.conf
-
-
-- name: restart kubelet
-  service: 
-    name: kubelet
-    state: restarted  
-  tags: haproxy  
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+  tags: haproxy

--- a/roles/haproxy/tasks/install.yml
+++ b/roles/haproxy/tasks/install.yml
@@ -1,11 +1,46 @@
 ---
-- name: add haproxy ppa repo
-  ansible.builtin.apt_repository:
-    repo: ppa:vbernat/haproxy-2.7
-  tags: haproxy  
-
-- name: install haproxy    
+- name: Install required packages for HAProxy repository
   ansible.builtin.apt:
-    name: ["haproxy=2.7.9-1ppa1~jammy"]
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
     update_cache: yes
-  tags: haproxy   
+  tags: haproxy
+
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  tags: haproxy
+
+- name: Download HAProxy GPG key
+  ansible.builtin.get_url:
+    url: https://haproxy.debian.net/bernat.debian.org.gpg
+    dest: /etc/apt/keyrings/haproxy.gpg
+    mode: '0644'
+  tags: haproxy
+
+- name: Add HAProxy official repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/haproxy.gpg] https://haproxy.debian.net {{ ansible_distribution_release }}-backports-{{ haproxy_version }} main"
+    filename: haproxy
+    state: present
+  tags: haproxy
+
+- name: Install HAProxy
+  ansible.builtin.apt:
+    name: haproxy
+    state: present
+    update_cache: yes
+  tags: haproxy
+
+- name: Enable and start HAProxy service
+  ansible.builtin.systemd:
+    name: haproxy
+    enabled: yes
+    state: started
+  tags: haproxy

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -34,11 +34,12 @@ defaults
 
 # Stats frontend for monitoring
 frontend stats
-    bind *:{{ haproxy_stats_port }}
+    bind 127.0.0.1:{{ haproxy_stats_port }}
     mode http
     stats enable
     stats uri {{ haproxy_stats_uri }}
     stats refresh {{ haproxy_stats_refresh }}
+    stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
     stats show-legends
     stats show-node
 

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,53 +1,61 @@
 global
-	log /dev/log	local0
-	log /dev/log	local1 notice
-	chroot /var/lib/haproxy
-	stats socket /run/haproxy/admin.sock mode 660 level admin
-	stats timeout 30s
-	user haproxy
-	group haproxy
-	daemon
+    log /dev/log local0
+    log /dev/log local1 notice
+    chroot /var/lib/haproxy
+    stats socket /run/haproxy/admin.sock mode 660 level admin
+    stats timeout 30s
+    user haproxy
+    group haproxy
+    daemon
 
-	# Default SSL material locations
-	ca-base /etc/ssl/certs
-	crt-base /etc/ssl/private
+    # Default SSL material locations
+    ca-base /etc/ssl/certs
+    crt-base /etc/ssl/private
 
-	# Default ciphers to use on SSL-enabled listening sockets.
-	# For more information, see ciphers(1SSL). This list is from:
-	#  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
-	# An alternative list with additional directives can be obtained from
-	#  https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy
-	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
-	ssl-default-bind-options no-sslv3
+    # Modern SSL configuration
+    ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 no-tlsv11
 
 defaults
-	log	global
-	mode	http
-	option	httplog
-	option	dontlognull
-  timeout connect 5000
-  timeout client  50000
-  timeout server  50000
-	errorfile 400 /etc/haproxy/errors/400.http
-	errorfile 403 /etc/haproxy/errors/403.http
-	errorfile 408 /etc/haproxy/errors/408.http
-	errorfile 500 /etc/haproxy/errors/500.http
-	errorfile 502 /etc/haproxy/errors/502.http
-	errorfile 503 /etc/haproxy/errors/503.http
-	errorfile 504 /etc/haproxy/errors/504.http
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
 
+# Stats frontend for monitoring
+frontend stats
+    bind *:{{ haproxy_stats_port }}
+    mode http
+    stats enable
+    stats uri {{ haproxy_stats_uri }}
+    stats refresh {{ haproxy_stats_refresh }}
+    stats show-legends
+    stats show-node
+
+# Kubernetes API Server frontend
 frontend k8s-api
-	bind {{ ansible_host }}:6443
-	bind 127.0.0.1:6443
-	mode tcp
-	option tcplog
-	default_backend k8s-api
+    bind {{ ansible_host }}:6443
+    bind 127.0.0.1:6443
+    mode tcp
+    option tcplog
+    default_backend k8s-api
 
+# Kubernetes API Server backend
 backend k8s-api
-	mode tcp
-	option tcp-check
-	balance roundrobin
-	default-server port 6443 inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
-  	server master-00 {{ hostvars[groups['kube_masters'][0]]['ansible_host'] }}:6443 check
-  	server master-01 {{ hostvars[groups['kube_masters'][1]]['ansible_host'] }}:6443 check
-  	server master-02 {{ hostvars[groups['kube_masters'][2]]['ansible_host'] }}:6443 check
+    mode tcp
+    option tcp-check
+    balance roundrobin
+    default-server port 6443 inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+{% for host in groups['kube_masters'] %}
+    server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['ansible_host'] }}:6443 check
+{% endfor %}

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -54,7 +54,7 @@ frontend k8s-api
 # Kubernetes API Server backend
 backend k8s-api
     mode tcp
-    option tcp-check
+    option ssl-hello-chk
     balance roundrobin
     default-server port 6443 inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
 {% for host in groups['kube_masters'] %}

--- a/roles/kube_masters/defaults/main.yml
+++ b/roles/kube_masters/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Calico CNI version
+calico_version: "3.29.1"
+
+# Kubernetes join token TTL (time to live)
+# Set to 24h for security - tokens should not be permanent
+token_ttl: "24h"

--- a/roles/kube_masters/tasks/after_install.yml
+++ b/roles/kube_masters/tasks/after_install.yml
@@ -12,6 +12,7 @@
   file:
     path: /opt/config/token.txt
     state: touch
+    mode: '0600'
     force: yes
   when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
   tags:

--- a/roles/kube_masters/tasks/after_install.yml
+++ b/roles/kube_masters/tasks/after_install.yml
@@ -65,7 +65,7 @@
 - name: permissions for admin.conf
   file:
     path: /etc/kubernetes/admin.conf
-    mode: 0775
+    mode: 0600
   tags:
     - first_masters
     - kube_masters
@@ -76,7 +76,7 @@
   copy:
     src: /etc/kubernetes/admin.conf
     dest: "~/.kube/config"
-    mode: 0755
+    mode: 0600
     remote_src: True
   become: false
   tags:
@@ -97,7 +97,7 @@
 
 - name: Get kubeadm token
   shell: |
-    kubeadm token create --print-join-command --ttl=0
+    kubeadm token create --print-join-command --ttl={{ token_ttl | default('24h') }}
   register: kubeadmToken
   when: inventory_hostname == "{{hostvars[groups['kube_masters'][0]]['inventory_hostname']}}"
   tags:

--- a/roles/kube_masters/templates/kubeadm-init.yaml.j2
+++ b/roles/kube_masters/templates/kubeadm-init.yaml.j2
@@ -1,9 +1,8 @@
-
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: "{{ansible_host}}"
-nodeRegistration:  
+nodeRegistration:
   criSocket: unix:///run/containerd/containerd.sock
 
 ---
@@ -15,19 +14,18 @@ controlPlaneEndpoint: "{{ansible_host}}:6443"
 apiServer:
   certSANs:
   - "127.0.0.1"
-  - "{{ hostvars[groups['kube_masters'][0]]['ansible_host'] }}"
-  - "{{ hostvars[groups['kube_masters'][1]]['ansible_host'] }}"
-  - "{{ hostvars[groups['kube_masters'][2]]['ansible_host'] }}"
+{% for host in groups['kube_masters'] %}
+  - "{{ hostvars[host]['ansible_host'] }}"
+{% endfor %}
   timeoutForControlPlane: 4m0s
 etcd:
   external:
     endpoints:
-    - "https://{{ hostvars[groups['kube_masters'][0]]['ansible_host'] }}:2379"
-    - "https://{{ hostvars[groups['kube_masters'][1]]['ansible_host'] }}:2379"
-    - "https://{{ hostvars[groups['kube_masters'][2]]['ansible_host'] }}:2379"
+{% for host in groups['kube_masters'] %}
+    - "https://{{ hostvars[host]['ansible_host'] }}:2379"
+{% endfor %}
     caFile: /etc/ssl/etcd/ca.pem
     certFile: /etc/ssl/etcd/client.pem
     keyFile: /etc/ssl/etcd/client-key.pem
 networking:
   podSubnet: "{{ CIDR }}"
-

--- a/roles/kube_workers/tasks/add.yml
+++ b/roles/kube_workers/tasks/add.yml
@@ -1,10 +1,18 @@
 ---
 
-- name: add worker to cluster
-  shell: |
-    cat token.txt | bash
-  args:
-    chdir: /opt/config/kubeadm
+- name: Read join command from token file
+  slurp:
+    src: /opt/config/kubeadm/token.txt
+  register: join_command_encoded
+  tags:
+    - kube_workers
+    - add
+
+- name: Join worker to cluster
+  command: "{{ join_command_encoded.content | b64decode | trim }}"
+  register: join_result
+  changed_when: "'This node has joined the cluster' in join_result.stdout"
+  failed_when: join_result.rc != 0 and 'already exists' not in join_result.stderr
   tags:
     - kube_workers
     - add

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -68,13 +68,19 @@
     filename: kubernetes
   tags: kubelet
 
-- name: Delete old packages
+- name: Check if node is part of cluster
+  stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: kubelet_conf
+  tags: kubelet
+
+- name: Delete old packages (only if not active cluster node)
   apt:
     name: ['kubelet', 'kubeadm', 'kubectl']
     update_cache: yes
     state: absent
     autoremove: true
-    force: true
+  when: not kubelet_conf.stat.exists
   tags: kubelet
 
 - name: Installing kubeadm, kubelet, kubectl with version

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -11,26 +11,61 @@
   tags: kubelet
 
 - name: create /etc/kubernetes/pki
-  file: 
+  file:
     path: /etc/kubernetes/pki
     state: directory
-  tags: kubelet  
+  tags: kubelet
 
 - name: Install pre packages
   apt:
-    name: ['apt-transport-https', 'aptitude']
+    name: ['apt-transport-https', 'aptitude', 'ca-certificates', 'curl', 'gnupg']
   tags: kubelet
 
-- name: Add kubernetes gpg key
-  apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    state: present
+- name: Create /etc/apt/keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
   tags: kubelet
 
-- name: Add kubernetes repositorie
+- name: Remove old kubernetes apt key (if exists)
+  file:
+    path: /etc/apt/trusted.gpg.d/kubernetes.gpg
+    state: absent
+  ignore_errors: yes
+  tags: kubelet
+
+- name: Remove old kubernetes repository (if exists)
   apt_repository:
     repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+    state: absent
+  ignore_errors: yes
+  tags: kubelet
+
+- name: Download Kubernetes GPG key
+  get_url:
+    url: https://pkgs.k8s.io/core:/stable:/v{{ kubeVersion | regex_replace('^([0-9]+\\.[0-9]+).*', '\\1') }}/deb/Release.key
+    dest: /tmp/kubernetes-release.key
+    mode: '0644'
+  tags: kubelet
+
+- name: Dearmor and install Kubernetes GPG key
+  shell: gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg < /tmp/kubernetes-release.key
+  args:
+    creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  tags: kubelet
+
+- name: Set permissions on keyring
+  file:
+    path: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    mode: '0644'
+  tags: kubelet
+
+- name: Add Kubernetes repository (pkgs.k8s.io)
+  apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v{{ kubeVersion | regex_replace('^([0-9]+\\.[0-9]+).*', '\\1') }}/deb/ /"
     state: present
+    filename: kubernetes
   tags: kubelet
 
 - name: Delete old packages
@@ -42,11 +77,33 @@
     force: true
   tags: kubelet
 
-- name: Installing kubeadm, kubelet, kubectl, and shared packages with version
+- name: Installing kubeadm, kubelet, kubectl with version
   apt:
-    name: ['kubelet={{kubeVersion}}-00', 'kubeadm={{kubeVersion}}-00', 'kubectl={{kubeVersion}}-00']
+    name:
+      - "kubelet={{ kubeVersion }}-*"
+      - "kubeadm={{ kubeVersion }}-*"
+      - "kubectl={{ kubeVersion }}-*"
     update_cache: yes
+    allow_downgrade: yes
   when: kubeVersion != "stable"
+  tags: kubelet
+
+- name: Hold kubelet package
+  dpkg_selections:
+    name: kubelet
+    selection: hold
+  tags: kubelet
+
+- name: Hold kubeadm package
+  dpkg_selections:
+    name: kubeadm
+    selection: hold
+  tags: kubelet
+
+- name: Hold kubectl package
+  dpkg_selections:
+    name: kubectl
+    selection: hold
   tags: kubelet
 
 - name: Enable & start kubelet


### PR DESCRIPTION
## Summary

- **Update component versions** to latest stable releases:
  - Kubernetes: 1.27.2 → 1.31.4
  - ETCD: v3.5.7 → v3.5.20
  - Calico: 3.26.0 → 3.29.1
  - HAProxy: 2.7.9 → 3.0.7
  - crictl: v1.26.0 → v1.31.1
  - containerd: 1.7.24 (new)
  - cfssl: R1.2 → 1.6.5

- **kubelet role**: migrate from deprecated `apt.kubernetes.io` to new `pkgs.k8s.io` repository, add package hold

- **etcd role**: dynamic masters support (no more hardcoded 3 masters), ECDSA certificates instead of RSA, updated cfssl from GitHub releases

- **containerd role**: template-based config.toml, removed kubeadm dependency for pause image

- **kube_masters role**: dynamic certSANs/etcd endpoints, 24h token TTL (was infinite), fixed file permissions (0600)

- **kube_workers role**: **fixed shell injection vulnerability** - replaced `cat token.txt | bash` with safe slurp + command approach

- **haproxy role**: official HAProxy repository instead of PPA, dynamic backends, stats endpoint on port 8404

- **All roles**: added `defaults/main.yml` and `handlers/main.yml` for better maintainability

## Test plan

- [ ] Run `ansible-playbook --syntax-check -i hosts.ini install_kubernetes_cluster.yml`
- [ ] Deploy on staging environment
- [ ] Verify ETCD cluster health
- [ ] Verify Kubernetes nodes Ready status
- [ ] Verify HAProxy stats endpoint accessible
- [ ] Test adding new worker node with `add_kubernetes_node.yml`